### PR TITLE
fix: setup.cfg, supports adding submodules

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,82 @@
+name: Wheels
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+     - master
+  release:
+    types:
+      - published
+
+env:
+  CIBW_TEST_COMMAND: python {project}/tests/test.py
+
+
+jobs:
+  build_sdist:
+    name: Build SDist
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Build SDist
+      run: pipx run build --sdist
+
+    - name: Check metadata
+      run: pipx run twine check dist/*
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: dist/*.tar.gz
+
+
+  build_wheels:
+    name: Wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]  # Windows wheels currently not supported very well by scikit-build
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - uses: joerick/cibuildwheel@v1.10.0
+      env:
+        # Python 2.7 on Windows with workaround not supported by scikit-build
+        CIBW_SKIP: cp27-win*
+
+    - name: Verify clean directory
+      run: git diff --exit-code
+      shell: bash
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v2
+      with:
+        path: wheelhouse/*.whl
+
+
+  upload_all:
+    name: Upload if release
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    steps:
+    - uses: actions/setup-python@v2
+
+    - uses: actions/download-artifact@v2
+      with:
+        name: artifact
+        path: dist
+
+    - uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,28 +1,18 @@
-cmake_minimum_required(VERSION 3.15...3.18)
+cmake_minimum_required(VERSION 3.15...3.19)
 
 project(scikit_build_example VERSION "0.0.1")
 
-# Currently, Scikit-build does not support FindPython, so we convert the
-# provided hints ourselves.
 if(SKBUILD)
-  set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
-  set(Python_INCLUDE_DIR "${PYTHON_INCLUDE_DIR}")
-  set(Python_LIBRARY "${PYTHON_LIBRARY}")
-  set(DUMMY "${PYTHON_VERSION_STRING}")  # Not needed, silences a warning
+  # Scikit-Build does not add your site-packages to the search path automatically,
+  # so we need to add it _or_ the pybind11 specific directory here.
+  execute_process(
+    COMMAND
+      "${PYTHON_EXECUTABLE}" -c
+      "import pybind11; print(pybind11.get_cmake_dir())"
+    OUTPUT_VARIABLE _tmp_dir
+    OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ECHO STDOUT)
+  list(APPEND CMAKE_PREFIX_PATH "${_tmp_dir}")
 endif()
-
-set(Python_FIND_IMPLEMENTATIONS CPython PyPy)  # PyPy requires 3.18
-find_package(Python REQUIRED COMPONENTS Interpreter Development)
-
-# Scikit-Build does not add your site-packages to the search path automatically,
-# so we need to add it _or_ the pybind11 specific directory here.
-execute_process(
-  COMMAND
-    "${Python_EXECUTABLE}" -c
-    "import pybind11; print(pybind11.get_cmake_dir())"
-  OUTPUT_VARIABLE _tmp_dir
-  OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ECHO STDOUT)
-list(APPEND CMAKE_PREFIX_PATH "${_tmp_dir}")
 
 # Now we can find pybind11
 find_package(pybind11 CONFIG REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,3 +22,6 @@ pybind11_add_module(_core MODULE src/main.cpp)
 target_compile_definitions(_core PRIVATE VERSION_INFO=${PROJECT_VERSION})
 
 install(TARGETS _core DESTINATION .)
+
+# file(GLOB_RECURSE PY_FILE_LIST RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/src" src/*.py)
+# install(FILES ${PY_FILE_LIST} DESTINATION .)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[metadata]
+name = scikit_build_example
+version = 0.0.1
+author = Henry Schreiner
+license = MIT
+description = a minimal example package (with pybind11)
+long_description = file: README.md
+long_description_content_type = text/markdown
+
+[options]
+python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,17 @@ except ImportError:
     )
     raise
 
+from setuptools import find_packages
+
+
 setup(
     name="scikit_build_example",
     version="0.0.1",
     description="a minimal example package (with pybind11)",
     author="Henry Schreiner",
     license="MIT",
-    packages=["scikit_build_example"],
+    packages=find_packages(where = 'src'),
     package_dir={"": "src"},
     cmake_install_dir="src/scikit_build_example",
+    include_package_data = True,
 )

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ import sys
 
 try:
     from skbuild import setup
+    from setuptools import find_packages
 except ImportError:
     print(
         "Please update pip, you need pip 10 or greater,\n"
@@ -18,13 +19,8 @@ from setuptools import find_packages
 
 
 setup(
-    name="scikit_build_example",
-    version="0.0.1",
-    description="a minimal example package (with pybind11)",
-    author="Henry Schreiner",
-    license="MIT",
     packages=find_packages(where = 'src'),
-    package_dir={"": "src"},
-    cmake_install_dir="src/scikit_build_example",
+    package_dir={'': 'src'},
+    cmake_install_dir='src/scikit_build_example',
     include_package_data = True,
 )


### PR DESCRIPTION
Fixes an issue trying to add submodules discovered by @davidt0x. Packages should always use `find:`, with includes/excludes if needed, rather than listing the packages. There might be a bug in scikit-build that causes the manual way to fail.

Moving to a proper setup.cfg setup as well.

May not fix the bug, might be a bug in scikit-build. Also, not everything can move, scikit-build does not repeat setup.cfg for the options it modifies.