### PR TITLE
Add some more doc for new users

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,3 +41,15 @@ target_compile_definitions(_core PRIVATE VERSION_INFO=${PROJECT_VERSION})
 # `setup.py`, specifies `cmake_install_dir="src/scikit_build_example"`, so that the _core module final location
 # will be `src/scikit_build_example/./`
 install(TARGETS _core DESTINATION .)
+
+#
+# Optional, for pip editable mode, copy the module to src/scikit_build_example/ after each build
+# (so that modifications are usable without a full `pip install`
+#
+add_custom_command(
+    TARGET _core
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+    $<TARGET_FILE:_core>
+    ${CMAKE_CURRENT_LIST_DIR}/src/scikit_build_example/$<TARGET_FILE_NAME:_core>
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ project(scikit_build_example VERSION "0.0.1")
 
 #
 # Add pybind11:
-# 1/ Either by adding it to pyproject.toml build-system/requires
-# 2/ Either by adding it as a submodule
+# 1/ Either by adding it to pyproject.toml build-system/requires,
+# 2/ or by adding it as a submodule
 #
 
 # 1/ Here, we find pybind11 via python, using pyproject.toml build-system/requires

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,14 @@ cmake_minimum_required(VERSION 3.15...3.22)
 
 project(scikit_build_example VERSION "0.0.1")
 
+#
+# Add pybind11:
+# 1/ Either by adding it to pyproject.toml build-system/requires
+# 2/ Either by adding it as a submodule
+#
+
+# 1/ Here, we find pybind11 via python, using pyproject.toml build-system/requires
+# (this will work when running `pip install`, but not in a standard cmake build)
 if(SKBUILD)
   # Scikit-Build does not add your site-packages to the search path
   # automatically, so we need to add it _or_ the pybind11 specific directory
@@ -13,12 +21,23 @@ if(SKBUILD)
     OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ECHO STDOUT)
   list(APPEND CMAKE_PREFIX_PATH "${_tmp_dir}")
 endif()
-
 # Now we can find pybind11
 find_package(pybind11 CONFIG REQUIRED)
 
-pybind11_add_module(_core MODULE src/main.cpp)
+# 2/ As an alternative, we could also add pybind11 by pointing to a submodule somewhere in the repository
+#   (This would work for `pip install` and for regular cmake builds)
+# add_subdirectory(path/to/pybind11)
 
+#
+# Add our _core native module (which will be wrapped in a standard python package, see src/scikit_build_example/__init__.py)
+#
+pybind11_add_module(_core MODULE src/main.cpp)
 target_compile_definitions(_core PRIVATE VERSION_INFO=${PROJECT_VERSION})
 
+#
+# Installation
+#
+# Note about install paths:
+# `setup.py`, specifies `cmake_install_dir="src/scikit_build_example"`, so that the _core module final location
+# will be `src/scikit_build_example/./`
 install(TARGETS _core DESTINATION .)

--- a/README.md
+++ b/README.md
@@ -53,3 +53,58 @@ scikit_build_example.add(1, 2)
 ```
 
 [`cibuildwheel`]:          https://cibuildwheel.readthedocs.io
+
+Explanations
+------------
+
+_Structure of this repository, concerning the package building_
+
+````
+.
+├── CMakeLists.txt                   # Builds a native python module named "_core" whose source is in main.cpp
+├── src/
+│         ├── main.cpp               # Example of published functions (add, susbstract), which end up in the "_core" module
+│         │
+│         └── scikit_build_example/  #  A standard python package named "scikit_build_example" which imports   
+│             └── __init__.py        # "_core" functions and publishes them
+│             │
+│             └── __init__.pyi       #  (Optional, not present in this repo). You could add a stub file here
+│             │                      # in order to help users and to provide autocomplete inside IDEs.
+│             │
+│             └──_core.cpython-XX.so #  _core module location in pip editable mode (not committed in this repo) 
+|                                    #  (appears only after building the module)
+|
+├── pyproject.toml                   # Standard setuptools config. Add you build requirements here
+├── setup.py                         # Standard setuptools config. 
+├── _skbuild/                        # Temp build directory used by pip (mentioned in .gitignore)
+````
+
+_Structure inside site-packages after installation (`pip install .`)_
+````
+venv/lib/python3.XX/site-packages/scikit_build_example/
+├── __init__.py
+└── _core.cpython-XX.so*
+````
+
+_Note about cmake install path_
+
+`setup.py`, specifies `cmake_install_dir="src/scikit_build_example"`, and `CMakeLists.txt`specifies 
+`install(TARGETS _core DESTINATION .)` so that the _core module final location will be `src/scikit_build_example/`
+
+
+_Other elements in this repository_
+
+````
+├── docs/...                       # python_example documentation created by sphinx-quickstart
+├── tests/...                      # A simple test
+├── noxfile.py                     # Test runner and linter
+|
+├── conda.recipe/                  # Conda
+│         └── meta.yaml
+.github                            # Continuous integrations updates dependencies, and builds pip, wheels, and conda packages
+├── dependabot.yml
+└── workflows/ 
+│    ├── conda.yml
+│    ├── pip.yml
+│    └── wheels.yml
+````


### PR DESCRIPTION
Hello,

I added some doc which could help new users in their first steps.

* Structure of this repository (mentioning the _core module and the python package that wraps it)
* How to add pybind (either via pyproject.toml, or via a submodule)

Apart from this, I did one code modification in the CMake file: copy the module to src/scikit_build_example/ after each build, for pip editable mode.

Anyway, thanks for this template which helped me a lot.
