### PR TITLE
chore: simpler dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    ignore:
-      # Offical actions have moving tags like v1
-      # that are used, so they don't need updates here
-      - dependency-name: "actions/*"


### PR DESCRIPTION
Ignores no longer needed after April 2022. Dependabot keeps the same style pinning now.