### PR TITLE
Fix missing function signatures and docstrings in generated documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/_generate/
 
 # PyBuilder
 .pybuilder/

--- a/docs/python_example.rst
+++ b/docs/python_example.rst
@@ -1,1 +1,1 @@
-.. automodule:: python_example
+.. automodule:: scikit_build_example


### PR DESCRIPTION
- Closes #136 
- Making this modification and rebuilding the docs with `make html` includes the function signature and docstrings in the generated documentation html files as below.  

![docs_with_fix](https://github.com/pybind/scikit_build_example/assets/15953349/a820d043-6e05-441b-bb07-70b6930e7933)
