### PR TITLE
ci: macos-latest is changing to macos-14 ARM runners

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-13, windows-latest]
+        platform: [ubuntu-latest, macos-12, windows-latest]
         python-version: ["3.8", "3.11"]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-13, windows-latest]
         python-version: ["3.8", "3.11"]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-latest, macos-latest, ubuntu-latest]
+        platform: [windows-latest, macos-13, ubuntu-latest]
         python-version: ["3.7", "3.12", "pypy-3.9"]
 
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos