### PR TITLE
Change Android x86_64 runner from macos-13 to ubuntu-latest

### DIFF
--- a/.github/workflows/cibw-cc.yaml
+++ b/.github/workflows/cibw-cc.yaml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         include:
           - platform: android
-            os: macos-13
+            os: ubuntu-latest
           - platform: android
             os: macos-latest
           - platform: ios


### PR DESCRIPTION
macos-13 will be [retired soon](https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/), and the macOS runners don't support the Android emulator anyway. So I don't think #173 ever actually passed the tests.