### PR TITLE
(cmake) use pybind11_add_module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,7 @@ find_package(pybind11 CONFIG REQUIRED)
 
 # Add a library using FindPython's tooling (pybind11 also provides a helper like
 # this)
-python_add_library(_core MODULE src/main.cpp WITH_SOABI)
-target_link_libraries(_core PRIVATE pybind11::headers)
+pybind11_add_module(_core src/main.cpp)
 
 # This is passing in the version as a define just as an example
 target_compile_definitions(_core PRIVATE VERSION_INFO=${PROJECT_VERSION})


### PR DESCRIPTION
Replace `python_add_library` with `pybind11_add_module` and drop `target_link_libraries`.


In a fresh environment, I get

```
Processing /XXX/tool-packaging
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: scikit_build_example
  Building wheel for scikit_build_example (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Building wheel for scikit_build_example (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [22 lines of output]
      *** scikit-build-core 0.11.6 using CMake 3.22.1 (wheel)
      *** Configuring CMake...
      loading initial cache file /tmp/tmp8uxxcscg/build/CMakeInit.txt
      -- The CXX compiler identification is GNU 11.4.0
      -- Detecting CXX compiler ABI info
      -- Detecting CXX compiler ABI info - done
      -- Check for working CXX compiler: /usr/bin/g++ - skipped
      -- Detecting CXX compile features
      -- Detecting CXX compile features - done
      -- Found PythonInterp: /XXX/venv/bin/python3 (found suitable version "3.10.8", minimum required is "3.8")
      -- Found PythonLibs: /XXX/.pyenv/versions/3.10.8/lib/libpython3.10.a
      -- Performing Test HAS_FLTO_AUTO
      -- Performing Test HAS_FLTO_AUTO - Success
      -- Found pybind11: /XXX/pypto-packaging/venv/lib/python3.10/site-packages/pybind11/include (found version "3.0.1")
      CMake Error at CMakeLists.txt:17 (python_add_library):
        Unknown CMake command "python_add_library".


      -- Configuring incomplete, errors occurred!
      See also "/tmp/tmp8uxxcscg/build/CMakeFiles/CMakeOutput.log".

      *** CMake configuration failed
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for scikit_build_example
Failed to build scikit_build_example
error: failed-wheel-build-for-install

× Failed to build installable wheels for some pyproject.toml based projects
╰─> scikit_build_example
```