### PR TITLE
ci: fix conda-build under setup-miniconda v4

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -31,14 +31,16 @@ jobs:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
 
+      # conda-build is a conda plugin, so it must live in the base env next to
+      # conda itself (setup-miniconda activates a separate "test" env).
       - name: Prepare
-        run: conda install conda-build conda-verify pytest
+        run: conda install -n base conda-build
 
       - name: Build
-        run: conda build conda.recipe
+        run: conda build conda.recipe --python=${{ matrix.python-version }}
 
       - name: Install
-        run: conda install -c ${CONDA_PREFIX}/conda-bld/ scikit_build_example
+        run: conda install --use-local scikit_build_example pytest
 
       - name: Test
         run: pytest tests


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The Conda workflow has been red on master since a June dependabot bump. `setup-miniconda` v4 changed its default `activate-environment` from base to a separate `test` env, so `conda install conda-build` landed in `test` instead of base. Modern conda-build is a conda plugin that only registers with the `conda` in its own env, so base's `conda` stopped recognizing the `build` subcommand and the recipe build failed with `invalid choice: 'build'`.

This installs conda-build into base, builds for the matrix Python so the artifact ABI matches the `test` env, and installs the result with `--use-local`. Also drops the unmaintained `conda-verify`.

A longer-term move to rattler-build is still worth doing; this just gets CI green.